### PR TITLE
Fixes the form api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -142,9 +142,11 @@ Return:
   ],
   "Roster": ["<string>"],
   "ChunksPerBallot": "<int>",
+  "BallotCount": "<int>",
   "BallotSize": "<int>",
   "Configuration": {<Configuration>},
-  "Voters": ["<string>"]
+  "Voters": ["<string>"],
+  "Owners": ["<string>"],
 }
 ```
 

--- a/proxy/election.go
+++ b/proxy/election.go
@@ -457,6 +457,11 @@ func (form *form) Form(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	votersAsStr := make([]string, len(formFromStore.Voters))
+	for i := range formFromStore.Voters {
+		votersAsStr[i] = strconv.Itoa(formFromStore.Voters[i])
+	}
+
 	response := ptypes.GetFormResponse{
 		FormID:          string(formFromStore.FormID),
 		Configuration:   formFromStore.Configuration,
@@ -465,8 +470,9 @@ func (form *form) Form(w http.ResponseWriter, r *http.Request) {
 		Result:          formFromStore.DecryptedBallots,
 		Roster:          roster,
 		ChunksPerBallot: formFromStore.ChunksPerBallot(),
+		BallotCount:     len(suff.VoterIDs),
 		BallotSize:      formFromStore.BallotSize,
-		Voters:          suff.VoterIDs,
+		Voters:          votersAsStr,
 	}
 
 	txnmanager.SendResponse(w, response)

--- a/proxy/election.go
+++ b/proxy/election.go
@@ -462,6 +462,11 @@ func (form *form) Form(w http.ResponseWriter, r *http.Request) {
 		votersAsStr[i] = strconv.Itoa(formFromStore.Voters[i])
 	}
 
+	ownersAsStr := make([]string, len(formFromStore.Owners))
+	for i := range formFromStore.Owners {
+		ownersAsStr[i] = strconv.Itoa(formFromStore.Owners[i])
+	}
+
 	response := ptypes.GetFormResponse{
 		FormID:          string(formFromStore.FormID),
 		Configuration:   formFromStore.Configuration,
@@ -473,6 +478,7 @@ func (form *form) Form(w http.ResponseWriter, r *http.Request) {
 		BallotCount:     len(suff.VoterIDs),
 		BallotSize:      formFromStore.BallotSize,
 		Voters:          votersAsStr,
+		Owners:          ownersAsStr,
 	}
 
 	txnmanager.SendResponse(w, response)

--- a/proxy/types/election.go
+++ b/proxy/types/election.go
@@ -58,6 +58,7 @@ type GetFormResponse struct {
 	BallotSize      int
 	BallotCount     int
 	Voters          []string
+	Owners          []string
 }
 
 // LightForm represents a light version of the form

--- a/proxy/types/election.go
+++ b/proxy/types/election.go
@@ -56,6 +56,7 @@ type GetFormResponse struct {
 	Roster          []string
 	ChunksPerBallot int
 	BallotSize      int
+	BallotCount     int
 	Voters          []string
 }
 


### PR DESCRIPTION
The goal of this PR is to allow the frontend to access the list of the owners for each form.

It also removes the call to the Suffragia method, which is both costly and wrong. Indeed, as far as I understood it  returns the list of people who already voted and miss the users that have not voted yet (Note that even if it would be correct, it is still way more costly than just getting the list).  

