### PR TITLE
Frontend: Use and maintain operators on the blockchain

### DIFF
--- a/contracts/evoting/controller/action.go
+++ b/contracts/evoting/controller/action.go
@@ -183,7 +183,7 @@ func (a *RegisterAction) Execute(ctx node.Context) error {
 	router.HandleFunc(evotingPathSlash+"adminlist", ep.AdminList).Methods("GET")
 	router.HandleFunc(evotingPathSlash+"adminlist", eproxy.AllowCORS).Methods("OPTIONS")
 	router.HandleFunc(evotingPathSlash+"addoperator", ep.AddOperator).Methods("POST")
-	router.HandleFunc(evotingPathSlash+"removeoperatot", ep.RemoveOperator).Methods("POST")
+	router.HandleFunc(evotingPathSlash+"removeoperator", ep.RemoveOperator).Methods("POST")
 	router.HandleFunc(evotingPathSlash+"operatorlist", ep.OperatorList).Methods("GET")
 	router.HandleFunc(evotingPathSlash+"operatorlist", eproxy.AllowCORS).Methods("OPTIONS")
 	router.HandleFunc(formIDPath+"/addowner", ep.AddOwnerToForm).Methods("POST")

--- a/contracts/evoting/evoting.go
+++ b/contracts/evoting/evoting.go
@@ -957,6 +957,7 @@ func (e evotingCommand) manageAdminOperatorList(snap store.Snapshot, step execut
 				return xerrors.Errorf("failed to initialize the operator list: %v", err)
 			}
 
+			return nil
 		}
 		if !isOperator {
 			return xerrors.Errorf("The performing user is not an operator.")

--- a/proxy/election.go
+++ b/proxy/election.go
@@ -38,23 +38,29 @@ func NewForm(srv ordering.Service, p pool.Pool,
 
 	logger := dela.Logger.With().Timestamp().Str("role", "evoting-proxy").Logger()
 
-	// Compute the ID of the admin list id
-	// We need it to filter the send list of form
+	// Compute the IDs of the admin and operator lists
+	// We need them to filter the send list of form
 	h := sha256.New()
 	h.Write([]byte(evoting.AdminListId))
 	adminListIDBuf := h.Sum(nil)
 	adminListID := hex.EncodeToString(adminListIDBuf)
 
+	h = sha256.New()
+	h.Write([]byte(evoting.OperatorListId))
+	operatorListIDBuf := h.Sum(nil)
+	operatorListID := hex.EncodeToString(operatorListIDBuf)
+
 	return &form{
-		logger:      logger,
-		orderingSvc: srv,
-		context:     ctx,
-		formFac:     fac,
-		adminFac:    types.AdminListFactory{},
-		mngr:        txnManaxer,
-		pool:        p,
-		pk:          pk,
-		adminListID: adminListID,
+		logger:         logger,
+		orderingSvc:    srv,
+		context:        ctx,
+		formFac:        fac,
+		adminFac:       types.AdminListFactory{},
+		mngr:           txnManaxer,
+		pool:           p,
+		pk:             pk,
+		adminListID:    adminListID,
+		operatorListID: operatorListID,
 	}
 }
 
@@ -64,15 +70,16 @@ func NewForm(srv ordering.Service, p pool.Pool,
 type form struct {
 	sync.Mutex
 
-	orderingSvc ordering.Service
-	logger      zerolog.Logger
-	context     serde.Context
-	formFac     serde.Factory
-	adminFac    serde.Factory
-	mngr        txnmanager.Manager
-	pool        pool.Pool
-	pk          kyber.Point
-	adminListID string
+	orderingSvc    ordering.Service
+	logger         zerolog.Logger
+	context        serde.Context
+	formFac        serde.Factory
+	adminFac       serde.Factory
+	mngr           txnmanager.Manager
+	pool           pool.Pool
+	pk             kyber.Point
+	adminListID    string
+	operatorListID string
 }
 
 // NewForm implements proxy.Proxy
@@ -500,9 +507,11 @@ func (form *form) Forms(w http.ResponseWriter, r *http.Request) {
 
 	allFormsInfo := make([]ptypes.LightForm, len(elecMD.FormsIDs))
 
+	adminFormsSeen := 0
+
 	// get the forms
 	for i, id := range elecMD.FormsIDs {
-		if id != form.adminListID {
+		if id != form.adminListID && id != form.operatorListID {
 			form, err := types.FormFromStore(form.context, form.formFac, id, form.orderingSvc.GetStore())
 			if err != nil {
 				InternalError(w, r, xerrors.Errorf("failed to get form: %v", err), nil)
@@ -538,11 +547,13 @@ func (form *form) Forms(w http.ResponseWriter, r *http.Request) {
 				Owners: ownersAsStr,
 			}
 
-			allFormsInfo[i] = info
+			allFormsInfo[i-adminFormsSeen] = info
+		} else {
+			adminFormsSeen++
 		}
 	}
 
-	response := ptypes.GetFormsResponse{Forms: allFormsInfo}
+	response := ptypes.GetFormsResponse{Forms: allFormsInfo[0 : len(elecMD.FormsIDs)-adminFormsSeen]}
 
 	txnmanager.SendResponse(w, response)
 

--- a/web/frontend/src/components/utils/Endpoints.tsx
+++ b/web/frontend/src/components/utils/Endpoints.tsx
@@ -8,8 +8,8 @@ export const ENDPOINT_LOGOUT = '/api/logout';
 export const ENDPOINT_USER_RIGHTS = '/api/user_rights';
 export const ENDPOINT_ADD_ROLE = '/api/add_role';
 export const ENDPOINT_REMOVE_ROLE = '/api/remove_role';
-export const ENDPOINT_ADD_ADMIN = '/api/evoting/auth/addadmin';
-export const ENDPOINT_REMOVE_ADMIN = '/api/evoting/auth/removeadmin';
+export const endpointAddRole = (role: UserRole) => `/api/evoting/auth/add${role}`;
+export const endpointRemoveRole = (role: UserRole) => `/api/evoting/auth/remove${role}`;
 export const checkTransaction = (token: string) => `/api/evoting/transactions/${token}`;
 
 export const newForm = '/api/evoting/forms';
@@ -40,6 +40,7 @@ export const form = (proxy: string, FormID: string) =>
   new URL(`/evoting/forms/${FormID}`, proxy).href;
 export const forms = (proxy: string) => new URL('/evoting/forms', proxy).href;
 export const adminlist = (proxy: string) => new URL('/evoting/adminlist', proxy).href;
+export const operatorlist = (proxy: string) => new URL('/evoting/operatorlist', proxy).href;
 
 // get the default proxy address
 export const getProxyConfig = '/api/config/proxy';

--- a/web/frontend/src/index.tsx
+++ b/web/frontend/src/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC, ReactElement, createContext, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import * as endpoints from 'components/utils/Endpoints';
-import { ENDPOINT_PERSONAL_INFO, adminlist } from 'components/utils/Endpoints';
+import { ENDPOINT_PERSONAL_INFO, adminlist, operatorlist } from 'components/utils/Endpoints';
 
 import 'index.css';
 import App from 'layout/App';
@@ -255,22 +255,42 @@ const AppContainer = () => {
       }
       // wait for the default proxy to be set
       await setDefaultProxy();
-      const admins = await fetch(adminlist(defaultProxyState.getProxy()), req);
+
       let adminResult;
-      if (admins.status === 200) {
-        adminResult = await admins.json();
-      } else {
-        adminResult = { Admins: [] };
-      }
+      let operatorResult;
+
+      const adminPromise = fetch(adminlist(defaultProxyState.getProxy()), req).then(async (res) => {
+        if (res.status === 200) {
+          adminResult = await res.json();
+        } else {
+          adminResult = { Admins: [] };
+        }
+      });
+
+      const operatorPromise = fetch(operatorlist(defaultProxyState.getProxy()), req).then(
+        async (res) => {
+          if (res.status === 200) {
+            operatorResult = await res.json();
+          } else {
+            operatorResult = { Operators: [] };
+          }
+        }
+      );
+
+      await adminPromise;
+      await operatorPromise;
+
       const isAdmin =
         adminResult.Admins.includes(result.sciper.toString()) || adminResult.Admins.length === 0;
+      const isOperator = operatorResult.Operator.includes(result.sciper.toString());
+
       setAuth({
         isLogged: result.isLoggedIn,
         firstName: result.firstName,
         lastName: result.lastName,
         sciper: result.sciper,
         isAdmin: isAdmin,
-        isOperator: isAdmin,
+        isOperator: isOperator,
         formsAuthorizations: arr,
         authorization: result.isLoggedIn ? new Map(Object.entries(result.authorization)) : arr,
         isAllowed: function (subject: string, action: string) {
@@ -297,7 +317,6 @@ const AppContainer = () => {
     </FlashContext.Provider>
   );
 };
-
 // Main entry point
 ReactDOM.render(
   <React.StrictMode>

--- a/web/frontend/src/index.tsx
+++ b/web/frontend/src/index.tsx
@@ -85,6 +85,7 @@ class FlashMessage {
     return this.level;
   }
 }
+
 const flashM = new FlashMessage('', 1);
 const defaultFlashState = {
   getMessages: function (): FlashMessage[] {
@@ -153,7 +154,9 @@ const Failed: FC = ({ children }) => (
     <div className="px-5 py-3 bg-white rounded-md shadow-xl">
       <div className="flex flex-col items-center">
         <div className="p-4">
-          <h1 className="text-2xl font-medium text-slate-600 pb-2">Failed to get personal info.</h1>
+          <h1 className="text-2xl font-medium text-slate-600 pb-2">
+            Failed to fetch users informations.
+          </h1>
           <p className="text-sm tracking-tight font-light text-slate-400 leading-6">
             Is the backend running ?
           </p>
@@ -282,7 +285,8 @@ const AppContainer = () => {
 
       const isAdmin =
         adminResult.Admins.includes(result.sciper.toString()) || adminResult.Admins.length === 0;
-      const isOperator = operatorResult.Operator.includes(result.sciper.toString());
+      // In order to simplify checks in the code, since an admin also has operator rights, an admin is also an operator
+      const isOperator = isAdmin || operatorResult.Operators.includes(result.sciper.toString());
 
       setAuth({
         isLogged: result.isLoggedIn,

--- a/web/frontend/src/layout/App.tsx
+++ b/web/frontend/src/layout/App.tsx
@@ -92,7 +92,7 @@ const App = () => {
               <Route
                 path={ROUTE_ADMIN}
                 element={
-                  <RequireAuth requireAdmin>
+                  <RequireAuth requireOperator>
                     <Admin />
                   </RequireAuth>
                 }

--- a/web/frontend/src/pages/admin/Admin.tsx
+++ b/web/frontend/src/pages/admin/Admin.tsx
@@ -67,28 +67,37 @@ const Admin: FC = () => {
   }, [abortController, t, nodeProxyObject, nodeProxyError]);
 
   useEffect(() => {
-    fetch(endpoints.adminlist(proxyCtx.getProxy()))
-      .then((resp) => {
+    const fetchAdminsAndOps = async () => {
+      const adminReq = fetch(endpoints.adminlist(proxyCtx.getProxy()));
+      const operatorReq = fetch(endpoints.operatorlist(proxyCtx.getProxy()));
+      try {
+        const adminResp = await adminReq;
+        const operatorResp = await operatorReq;
         setLoading(false);
-        if (resp.status === 200) {
-          const jsonData = resp.json();
-          jsonData.then((result) => {
-            const admins = result.Admins.map((x) => ({
-              sciper: x.toString(),
-              role: UserRole.Admin,
-            }));
-            setUsers(admins);
-          });
-        } else {
-          setUsers([]);
-          fctx.addMessage(t('errorFetchingUsers'), FlashLevel.Error);
+        let roleList = [];
+        if (adminResp.status === 200) {
+          const result = await adminResp.json();
+          roleList = result.Admins.map((x) => ({
+            sciper: x,
+            role: UserRole.Admin,
+          }));
         }
-      })
-      .catch((error) => {
-        setLoading(false);
+        if (operatorResp.status === 200) {
+          const result = await operatorResp.json();
+          const operators = result.Operators.map((x) => ({
+            sciper: x,
+            role: UserRole.Operator,
+          }));
+          roleList = [...roleList, ...operators];
+        }
+        roleList.sort((x, y) => parseInt(x.sciper) - parseInt(y.sciper));
+        setUsers(roleList);
+      } catch (error) {
         setUsers([]);
-        fctx.addMessage(`${t('errorFetchingUsers')}: ${error.message}`, FlashLevel.Error);
-      });
+        fctx.addMessage(t(`errorFetchingUsers: ${error.message}`), FlashLevel.Error);
+      }
+    };
+    fetchAdminsAndOps();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -116,5 +125,4 @@ const Admin: FC = () => {
     <Loading />
   );
 };
-
 export default Admin;

--- a/web/frontend/src/pages/admin/AdminTable.tsx
+++ b/web/frontend/src/pages/admin/AdminTable.tsx
@@ -1,7 +1,7 @@
 import { FC, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { User } from 'types/userRole';
+import { User, UserRole } from 'types/userRole';
 import AddAdminUserModal from './components/AddAdminUserModal';
 import RemoveAdminUserModal from './components/RemoveAdminUserModal';
 import { AuthContext } from '../../index';
@@ -22,7 +22,7 @@ const AdminTable: FC<AdminTableProps> = ({ users, setUsers }) => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [newUserOpen, setNewUserOpen] = useState(false);
   const [scipersToDisplay, setScipersToDisplay] = useState([]);
-  const [sciperToDelete, setSciperToDelete] = useState('');
+  const [userToDelete, setUserToDelete] = useState({ sciper: '', role: UserRole.None });
   const [pageIndex, setPageIndex] = useState(0);
 
   const openModal = () => setNewUserOpen(true);
@@ -38,8 +38,8 @@ const AdminTable: FC<AdminTableProps> = ({ users, setUsers }) => {
     }
   }, [users, pageIndex]);
 
-  const handleDelete = (sciper: string): void => {
-    setSciperToDelete(sciper);
+  const handleDelete = (user): void => {
+    setUserToDelete(user);
     setShowDeleteModal(true);
   };
 
@@ -71,10 +71,11 @@ const AdminTable: FC<AdminTableProps> = ({ users, setUsers }) => {
   };
 
   const handleRemoveRoleUser = (): void => {
+    // TODO: This needs to be corrected in case the user has both admin and operator rights
     // Pulling the new admin list from the server would be a better way, but it leads to a race condition.
-    const newUsers = users.filter((user) => user.sciper !== sciperToDelete);
+    const newUsers = users.filter((user) => user.sciper !== userToDelete.sciper);
     // If the user removes his own admin rights, we remove his rights client side and redirect it to the homepage
-    if (sciperToDelete === authctx.sciper.toString() && users.length > 1) {
+    if (userToDelete.sciper === authctx.sciper.toString() && users.length > 1) {
       authctx.isAdmin = false;
       authctx.isOperator = false;
       navigate('/');
@@ -96,7 +97,8 @@ const AdminTable: FC<AdminTableProps> = ({ users, setUsers }) => {
       <RemoveAdminUserModal
         setOpen={setShowDeleteModal}
         open={showDeleteModal}
-        sciper={sciperToDelete}
+        sciper={userToDelete.sciper}
+        role={userToDelete.role}
         handleRemoveRoleUser={handleRemoveRoleUser}
       />
       <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-4 py-6 pl-2">
@@ -147,7 +149,7 @@ const AdminTable: FC<AdminTableProps> = ({ users, setUsers }) => {
                     {users.length > 1 && (
                       <div
                         className="cursor-pointer text-[#ff0000] hover:text-indigo-900"
-                        onClick={() => handleDelete(user.sciper)}>
+                        onClick={() => handleDelete(user)}>
                         {t('delete')}
                       </div>
                     )}

--- a/web/frontend/src/pages/admin/AdminTable.tsx
+++ b/web/frontend/src/pages/admin/AdminTable.tsx
@@ -57,6 +57,10 @@ const AdminTable: FC<AdminTableProps> = ({ users, setUsers }) => {
 
   const handleAddRoleUser = (user: User): void => {
     // Pulling the new admin list from the server would be a better way, but it leads to a race condition.
+    // We don't do anything if the user already has the required role
+    if (users.some((oldUser) => oldUser.sciper === user.sciper && oldUser.role === user.role)) {
+      return;
+    }
     const newUsers = [...users, user];
     // All users are considered admins as long as there is none on the admin list. So when someone gives admins rights
     // to someone else, he will lose its own "by default" admins rights
@@ -71,19 +75,25 @@ const AdminTable: FC<AdminTableProps> = ({ users, setUsers }) => {
   };
 
   const handleRemoveRoleUser = (): void => {
-    // TODO: This needs to be corrected in case the user has both admin and operator rights
     // Pulling the new admin list from the server would be a better way, but it leads to a race condition.
-    const newUsers = users.filter((user) => user.sciper !== userToDelete.sciper);
+    const newUsers = users.filter(
+      (user) => !(user.sciper === userToDelete.sciper && user.role === userToDelete.role)
+    );
     // If the user removes his own admin rights, we remove his rights client side and redirect it to the homepage
-    if (userToDelete.sciper === authctx.sciper.toString() && users.length > 1) {
-      authctx.isAdmin = false;
-      authctx.isOperator = false;
-      navigate('/');
-    } else if (newUsers.length > 0) {
-      setUsers(newUsers);
-      if (newUsers.length % SCIPERS_PER_PAGE === 0) {
-        setPageIndex(pageIndex - 1);
+    if (userToDelete.sciper === authctx.sciper.toString()) {
+      authctx.isAdmin = newUsers.some(
+        (user) => user.sciper === userToDelete.sciper && user.role === UserRole.Admin
+      );
+      authctx.isOperator = newUsers.some(
+        (user) => user.sciper === userToDelete.sciper && user.role === UserRole.Operator
+      );
+      if (!(authctx.isAdmin || authctx.isOperator)) {
+        navigate('/');
       }
+    }
+    setUsers(newUsers);
+    if (newUsers.length % SCIPERS_PER_PAGE === 0) {
+      setPageIndex(pageIndex - 1);
     }
   };
 
@@ -139,20 +149,25 @@ const AdminTable: FC<AdminTableProps> = ({ users, setUsers }) => {
           </thead>
           <tbody>
             {scipersToDisplay !== undefined &&
-              scipersToDisplay.map((user) => (
-                <tr key={user.sciper} className="bg-white border-b hover:bg-gray-50">
+              scipersToDisplay.map((user, index) => (
+                <tr key={index} className="bg-white border-b hover:bg-gray-50">
                   <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                     {user.sciper}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{user.role}</td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                    {users.length > 1 && (
-                      <div
-                        className="cursor-pointer text-[#ff0000] hover:text-indigo-900"
-                        onClick={() => handleDelete(user)}>
-                        {t('delete')}
-                      </div>
-                    )}
+                    {
+                      // No delete button on admins when they are the only one
+                      (user.role !== UserRole.Admin ||
+                        (user.role === UserRole.Admin &&
+                          users.filter((u) => u.role === UserRole.Admin).length > 1)) && (
+                        <div
+                          className="cursor-pointer text-[#ff0000] hover:text-indigo-900"
+                          onClick={() => handleDelete(user)}>
+                          {t('delete')}
+                        </div>
+                      )
+                    }
                   </td>
                 </tr>
               ))}

--- a/web/frontend/src/pages/admin/components/AddAdminUserModal.tsx
+++ b/web/frontend/src/pages/admin/components/AddAdminUserModal.tsx
@@ -8,7 +8,7 @@ import SpinnerIcon from 'components/utils/SpinnerIcon';
 import { UserAddIcon } from '@heroicons/react/outline';
 import { AuthContext, FlashContext, FlashLevel } from 'index';
 import { User, UserRole } from 'types/userRole';
-import { ENDPOINT_ADD_ADMIN } from 'components/utils/Endpoints';
+import { endpointAddRole } from 'components/utils/Endpoints';
 import AdminModal from './AdminModal';
 import usePostCall from 'components/utils/usePostCall';
 
@@ -60,7 +60,7 @@ const AddAdminUserModal: FC<AddAdminUserModalProps> = ({ open, setOpen, handleAd
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(userToAdd),
     };
-    return sendFetchRequest(ENDPOINT_ADD_ADMIN, request, setIsPosting);
+    return sendFetchRequest(endpointAddRole(selectedRole), request, setIsPosting);
   };
   const handleAddUser = async () => {
     setLoading(true);

--- a/web/frontend/src/pages/admin/components/RemoveAdminUserModal.tsx
+++ b/web/frontend/src/pages/admin/components/RemoveAdminUserModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useContext, useEffect, useState } from 'react';
-import { ENDPOINT_REMOVE_ADMIN } from 'components/utils/Endpoints';
+import { endpointRemoveRole } from 'components/utils/Endpoints';
 import PropTypes from 'prop-types';
 import { Dialog } from '@headlessui/react';
 import { UserRemoveIcon } from '@heroicons/react/outline';
@@ -8,11 +8,13 @@ import { useTranslation } from 'react-i18next';
 import { FlashContext, FlashLevel } from 'index';
 import AdminModal from './AdminModal';
 import usePostCall from 'components/utils/usePostCall';
+import { UserRole } from '../../../types/userRole';
 
 type RemoveAdminUserModalProps = {
   open: boolean;
   setOpen(opened: boolean): void;
   sciper: string;
+  role: UserRole;
   handleRemoveRoleUser(): void;
 };
 
@@ -20,6 +22,7 @@ const RemoveAdminUserModal: FC<RemoveAdminUserModalProps> = ({
   open,
   setOpen,
   sciper,
+  role,
   handleRemoveRoleUser,
 }) => {
   const { t } = useTranslation();
@@ -46,7 +49,7 @@ const RemoveAdminUserModal: FC<RemoveAdminUserModalProps> = ({
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(userToBeRemoved),
     };
-    return sendFetchRequest(ENDPOINT_REMOVE_ADMIN, request, setIsPosting);
+    return sendFetchRequest(endpointRemoveRole(role), request, setIsPosting);
   };
   const handleDelete = async () => {
     setLoading(true);

--- a/web/frontend/src/types/userRole.ts
+++ b/web/frontend/src/types/userRole.ts
@@ -4,10 +4,11 @@ interface User {
 }
 
 export const enum UserRole {
+  // the strings for all the roles are compliant with the proxy api.
+  // Check for any issue before updating any string value
   None = '',
   Admin = 'admin',
   Operator = 'operator',
-  // the string for the 2 next role is compliant with the proxy api. Check for any issue before updating it
   Voter = 'voter',
   Owner = 'owner',
 }

--- a/web/frontend/tests/admins.spec.ts
+++ b/web/frontend/tests/admins.spec.ts
@@ -1,6 +1,6 @@
 import { assertHasFooter, assertHasNavBar, initI18n, logIn, setUp } from './shared';
 import { expect, test } from '@playwright/test';
-import { mockProxyList, SCIPER_ADMIN, SCIPER_OPERATOR } from './mocks/api';
+import { SCIPER_ADMIN, SCIPER_OPERATOR, mockProxyList } from './mocks/api';
 import { default as i18n } from 'i18next';
 import Worker0 from './json/api/proxies/dela-worker-0.json';
 import { UserRole } from '../src/types/userRole';

--- a/web/frontend/tests/admins.spec.ts
+++ b/web/frontend/tests/admins.spec.ts
@@ -1,6 +1,6 @@
 import { assertHasFooter, assertHasNavBar, initI18n, logIn, setUp } from './shared';
 import { expect, test } from '@playwright/test';
-import { SCIPER_ADMIN, SCIPER_OPERATOR, mockProxyList } from './mocks/api';
+import { SCIPER_ADMIN, SCIPER_NO_ROLE, SCIPER_OPERATOR, mockProxyList } from './mocks/api';
 import { default as i18n } from 'i18next';
 import Worker0 from './json/api/proxies/dela-worker-0.json';
 import { UserRole } from '../src/types/userRole';
@@ -55,7 +55,7 @@ test('Assert tables are present and have the right amount of rows', async ({ pag
 });
 
 test('Assert "Add admin" button is working', async ({ page, baseURL }) => {
-  const adminToAdd = '111111';
+  const adminToAdd = SCIPER_NO_ROLE;
   page.waitForRequest(async (request) => {
     const body = await request.postDataJSON();
     return (
@@ -109,7 +109,7 @@ test('Assert "Remove admin" button is working', async ({ page, baseURL }) => {
 });
 
 test('Assert "Add operator" button is working', async ({ page, baseURL }) => {
-  const operatorToAdd = '999999';
+  const operatorToAdd = SCIPER_NO_ROLE;
   page.waitForRequest(async (request) => {
     const body = await request.postDataJSON();
     return (

--- a/web/frontend/tests/admins.spec.ts
+++ b/web/frontend/tests/admins.spec.ts
@@ -1,6 +1,6 @@
 import { assertHasFooter, assertHasNavBar, initI18n, logIn, setUp } from './shared';
 import { expect, test } from '@playwright/test';
-import { SCIPER_ADMIN, mockProxyList } from './mocks/api';
+import { mockProxyList, SCIPER_ADMIN, SCIPER_OPERATOR } from './mocks/api';
 import { default as i18n } from 'i18next';
 import Worker0 from './json/api/proxies/dela-worker-0.json';
 import { UserRole } from '../src/types/userRole';
@@ -67,18 +67,18 @@ test('Assert "Add admin" button is working', async ({ page, baseURL }) => {
   await page.getByRole('button', { name: i18n.t('addUser') }).click();
   // menu should be visible
   const textbox = page.getByRole('textbox', { name: 'Sciper' });
-  const select = page.getByRole('button', { name: UserRole.Operator });
+  const select = page.getByLabel(i18n.t('enterSciper')).getByText(UserRole.Operator);
   await expect(textbox).toBeVisible();
   // add 1 admin
   await textbox.fill(adminToAdd);
   await expect(select).toBeVisible();
   await select.click();
   // select the admin role in the list box
-  const adminSelect = page.getByLabel(UserRole.Operator).getByText(UserRole.Admin);
+  const adminSelect = page.getByLabel(i18n.t('enterSciper')).getByText(UserRole.Admin);
   await expect(adminSelect).toBeVisible();
   await adminSelect.click();
   // click on confirmation
-  const addButton = await page
+  const addButton = page
     .getByLabel(i18n.t('enterSciper'))
     .getByRole('button', { name: i18n.t('addUser') });
   await addButton.click();
@@ -86,7 +86,7 @@ test('Assert "Add admin" button is working', async ({ page, baseURL }) => {
 });
 
 test('Assert "Remove admin" button is working', async ({ page, baseURL }) => {
-  const adminToRemove = '123456';
+  const adminToRemove = SCIPER_ADMIN;
   page.waitForRequest(async (request) => {
     const body = await request.postDataJSON();
     return (
@@ -98,6 +98,53 @@ test('Assert "Remove admin" button is working', async ({ page, baseURL }) => {
   await page
     .getByRole('row')
     .filter({ has: page.getByText(adminToRemove) })
+    .getByText(i18n.t('delete'))
+    .click();
+  const delButton = page
+    .getByLabel(i18n.t('confirmDeleteUserSciper'))
+    .getByRole('button', { name: i18n.t('delete') });
+  await expect(delButton).toBeVisible();
+  await delButton.click();
+  await expect(delButton).not.toBeVisible();
+});
+
+test('Assert "Add operator" button is working', async ({ page, baseURL }) => {
+  const operatorToAdd = '999999';
+  page.waitForRequest(async (request) => {
+    const body = await request.postDataJSON();
+    return (
+      request.url() === `${baseURL}/api/evoting/auth/addoperator` &&
+      request.method() === 'POST' &&
+      body.TargetUserID === operatorToAdd
+    );
+  });
+  await page.getByRole('button', { name: i18n.t('addUser') }).click();
+  // menu should be visible
+  const textbox = page.getByRole('textbox', { name: 'Sciper' });
+  await expect(textbox).toBeVisible();
+  // add 1 operator
+  await textbox.fill(operatorToAdd);
+  // click on confirmation
+  const addButton = page
+    .getByLabel(i18n.t('enterSciper'))
+    .getByRole('button', { name: i18n.t('addUser') });
+  await addButton.click();
+  await expect(addButton).not.toBeVisible();
+});
+
+test('Assert "Remove operator" button is working', async ({ page, baseURL }) => {
+  const operatorToRemove = SCIPER_OPERATOR;
+  page.waitForRequest(async (request) => {
+    const body = await request.postDataJSON();
+    return (
+      request.url() === `${baseURL}/api/evoting/auth/removeoperator` &&
+      request.method() === 'POST' &&
+      body.TargetUserID === operatorToRemove
+    );
+  });
+  await page
+    .getByRole('row')
+    .filter({ has: page.getByText(operatorToRemove) })
     .getByText(i18n.t('delete'))
     .click();
   const delButton = page

--- a/web/frontend/tests/admins.spec.ts
+++ b/web/frontend/tests/admins.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from '@playwright/test';
 import { SCIPER_ADMIN, mockProxyList } from './mocks/api';
 import { default as i18n } from 'i18next';
 import Worker0 from './json/api/proxies/dela-worker-0.json';
+import { UserRole } from '../src/types/userRole';
 
 initI18n();
 
@@ -43,7 +44,7 @@ test('Assert tables are present and have the right amount of rows', async ({ pag
       .getByRole('table')
       .filter({ has: page.getByText(i18n.t('role')) })
       .getByRole('row')
-  ).toHaveCount(3);
+  ).toHaveCount(5);
 
   await expect(
     page
@@ -65,10 +66,17 @@ test('Assert "Add admin" button is working', async ({ page, baseURL }) => {
   });
   await page.getByRole('button', { name: i18n.t('addUser') }).click();
   // menu should be visible
-  const textbox = await page.getByRole('textbox', { name: 'Sciper' });
+  const textbox = page.getByRole('textbox', { name: 'Sciper' });
+  const select = page.getByRole('button', { name: UserRole.Operator });
   await expect(textbox).toBeVisible();
   // add 1 admin
   await textbox.fill(adminToAdd);
+  await expect(select).toBeVisible();
+  await select.click();
+  // select the admin role in the list box
+  const adminSelect = page.getByLabel(UserRole.Operator).getByText(UserRole.Admin);
+  await expect(adminSelect).toBeVisible();
+  await adminSelect.click();
   // click on confirmation
   const addButton = await page
     .getByLabel(i18n.t('enterSciper'))

--- a/web/frontend/tests/footer.spec.ts
+++ b/web/frontend/tests/footer.spec.ts
@@ -1,13 +1,20 @@
 import { expect, test } from '@playwright/test';
 import { default as i18n } from 'i18next';
 import { initI18n, setUp } from './shared';
-import { SCIPER_ADMIN, SCIPER_OTHER_ADMIN, mockPersonalInfo } from './mocks/api';
-import { mockAdminList } from './mocks/evoting';
+import {
+  SCIPER_ADMIN,
+  SCIPER_OTHER_ADMIN,
+  mockPersonalInfo,
+  SCIPER_OPERATOR,
+  SCIPER_OTHER_OPERATOR
+} from './mocks/api';
+import { mockAdminList, mockOperatorList } from './mocks/evoting';
 
 initI18n();
 
 test.beforeEach(async ({ page }) => {
   await mockAdminList(page, [SCIPER_ADMIN, SCIPER_OTHER_ADMIN]);
+  await mockOperatorList(page, [SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR]);
   await mockPersonalInfo(page);
   await setUp(page, '/about');
 });

--- a/web/frontend/tests/footer.spec.ts
+++ b/web/frontend/tests/footer.spec.ts
@@ -3,10 +3,10 @@ import { default as i18n } from 'i18next';
 import { initI18n, setUp } from './shared';
 import {
   SCIPER_ADMIN,
-  SCIPER_OTHER_ADMIN,
-  mockPersonalInfo,
   SCIPER_OPERATOR,
-  SCIPER_OTHER_OPERATOR
+  SCIPER_OTHER_ADMIN,
+  SCIPER_OTHER_OPERATOR,
+  mockPersonalInfo,
 } from './mocks/api';
 import { mockAdminList, mockOperatorList } from './mocks/evoting';
 

--- a/web/frontend/tests/formIndex.spec.ts
+++ b/web/frontend/tests/formIndex.spec.ts
@@ -3,10 +3,12 @@ import { default as i18n } from 'i18next';
 import { assertHasFooter, assertHasNavBar, initI18n, logIn, setUp, translate } from './shared';
 import {
   SCIPER_ADMIN,
+  SCIPER_OPERATOR,
   SCIPER_OTHER_ADMIN,
+  SCIPER_OTHER_OPERATOR,
   SCIPER_OTHER_USER,
   SCIPER_USER,
-  mockPersonalInfo, SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR,
+  mockPersonalInfo,
 } from './mocks/api';
 import { mockAdminList, mockForms, mockOperatorList } from './mocks/evoting';
 import Forms from './json/formIndex.json';

--- a/web/frontend/tests/formIndex.spec.ts
+++ b/web/frontend/tests/formIndex.spec.ts
@@ -6,9 +6,9 @@ import {
   SCIPER_OTHER_ADMIN,
   SCIPER_OTHER_USER,
   SCIPER_USER,
-  mockPersonalInfo,
+  mockPersonalInfo, SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR,
 } from './mocks/api';
-import { mockAdminList, mockForms } from './mocks/evoting';
+import { mockAdminList, mockForms, mockOperatorList } from './mocks/evoting';
 import Forms from './json/formIndex.json';
 
 initI18n();
@@ -25,6 +25,7 @@ async function disableFilter(page: Page) {
 test.beforeEach(async ({ page }) => {
   // mock empty list per default
   await mockAdminList(page, [SCIPER_ADMIN, SCIPER_OTHER_ADMIN]);
+  await mockOperatorList(page, [SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR]);
   await mockForms(page, 'empty');
   await mockPersonalInfo(page);
   await setUp(page, '/form/index');

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -12,9 +12,9 @@ import {
   mockForms,
   mockPersonalInfo,
   mockProxies,
-  mockServicesShuffle,
+  mockServicesShuffle, SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR,
 } from './mocks/api';
-import { mockAdminList, mockDKGActors, mockFormsFormID } from './mocks/evoting';
+import { mockAdminList, mockDKGActors, mockFormsFormID, mockOperatorList } from './mocks/evoting';
 import { FORMID } from './mocks/shared';
 import Worker0 from './json/api/proxies/dela-worker-0.json';
 import Worker1 from './json/api/proxies/dela-worker-1.json';
@@ -50,6 +50,7 @@ async function setUpMocks(
   await mockDKGActors(page, dkgActorsStatus, initialized);
   await mockAPIDKGActors(page);
   await mockAdminList(page, [SCIPER_ADMIN, SCIPER_OTHER_ADMIN]);
+  await mockOperatorList(page, [SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR]);
   await mockPersonalInfo(page, SCIPER_ADMIN); // initially log in as admin to be able to access page
   await mockDKGActorsFormID(page);
   await mockServicesShuffle(page);

--- a/web/frontend/tests/forms.spec.ts
+++ b/web/frontend/tests/forms.spec.ts
@@ -3,7 +3,9 @@ import { default as i18n } from 'i18next';
 import { assertHasFooter, assertHasNavBar, initI18n, logIn, setUp } from './shared';
 import {
   SCIPER_ADMIN,
+  SCIPER_OPERATOR,
   SCIPER_OTHER_ADMIN,
+  SCIPER_OTHER_OPERATOR,
   SCIPER_OTHER_USER,
   SCIPER_USER,
   mockDKGActors as mockAPIDKGActors,
@@ -12,7 +14,7 @@ import {
   mockForms,
   mockPersonalInfo,
   mockProxies,
-  mockServicesShuffle, SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR,
+  mockServicesShuffle,
 } from './mocks/api';
 import { mockAdminList, mockDKGActors, mockFormsFormID, mockOperatorList } from './mocks/evoting';
 import { FORMID } from './mocks/shared';

--- a/web/frontend/tests/mocks/api.ts
+++ b/web/frontend/tests/mocks/api.ts
@@ -6,6 +6,7 @@ export const SCIPER_USER = '789012';
 export const SCIPER_OTHER_USER = '654321';
 export const SCIPER_OPERATOR = '111111';
 export const SCIPER_OTHER_OPERATOR = '222222';
+export const SCIPER_NO_ROLE = '999999';
 
 // /api/evoting
 

--- a/web/frontend/tests/mocks/api.ts
+++ b/web/frontend/tests/mocks/api.ts
@@ -4,6 +4,8 @@ export const SCIPER_ADMIN = '123456';
 export const SCIPER_OTHER_ADMIN = '987654';
 export const SCIPER_USER = '789012';
 export const SCIPER_OTHER_USER = '654321';
+export const SCIPER_OPERATOR = '111111';
+export const SCIPER_OTHER_OPERATOR = '222222';
 
 // /api/evoting
 

--- a/web/frontend/tests/mocks/evoting.ts
+++ b/web/frontend/tests/mocks/evoting.ts
@@ -28,6 +28,29 @@ export async function mockAdminList(page: Page, adminList: string[]) {
   });
 }
 
+export async function mockOperatorList(page: Page, operatorList: string[]) {
+  // Clears the mocked route of any already setup mocked response
+  await page.unroute(`${process.env.DELA_PROXY_URL}/evoting/operatorlist`);
+  // Sets up a mocked response to a call to this URL
+  await page.route(`${process.env.DELA_PROXY_URL}/evoting/operatorlist`, async (route) => {
+    if (route.request().method() === 'OPTIONS') {
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'Access-Control-Allow-Headers': '*',
+          'Access-Control-Allow-Origin': '*',
+        },
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: `{"Operators": ${JSON.stringify(operatorList)}}`,
+      });
+    }
+  });
+}
+
 export async function mockForms(page: Page, formList: string) {
   // clear current mock
   await page.unroute(`${process.env.DELA_PROXY_URL}/evoting/forms`);

--- a/web/frontend/tests/navbar.spec.ts
+++ b/web/frontend/tests/navbar.spec.ts
@@ -9,10 +9,12 @@ import {
 } from './shared';
 import {
   SCIPER_ADMIN,
+  SCIPER_OPERATOR,
   SCIPER_OTHER_ADMIN,
+  SCIPER_OTHER_OPERATOR,
   SCIPER_USER,
   mockLogout,
-  mockPersonalInfo, SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR,
+  mockPersonalInfo,
 } from './mocks/api';
 import { mockAdminList, mockOperatorList } from './mocks/evoting';
 

--- a/web/frontend/tests/navbar.spec.ts
+++ b/web/frontend/tests/navbar.spec.ts
@@ -12,14 +12,15 @@ import {
   SCIPER_OTHER_ADMIN,
   SCIPER_USER,
   mockLogout,
-  mockPersonalInfo,
+  mockPersonalInfo, SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR,
 } from './mocks/api';
-import { mockAdminList } from './mocks/evoting';
+import { mockAdminList, mockOperatorList } from './mocks/evoting';
 
 initI18n();
 
 test.beforeEach(async ({ page }) => {
   await mockAdminList(page, [SCIPER_ADMIN, SCIPER_OTHER_ADMIN]);
+  await mockOperatorList(page, [SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR]);
   await mockPersonalInfo(page);
   await setUp(page, '/about');
 });

--- a/web/frontend/tests/result.spec.ts
+++ b/web/frontend/tests/result.spec.ts
@@ -2,9 +2,15 @@ import { expect, test } from '@playwright/test';
 import { default as i18n } from 'i18next';
 import { assertHasFooter, assertHasNavBar, initI18n, setUp } from './shared';
 import { FORMID } from './mocks/shared';
-import { mockAdminList, mockFormsFormID } from './mocks/evoting';
+import { mockAdminList, mockFormsFormID, mockOperatorList } from './mocks/evoting';
 import Form from './json/evoting/forms/combined.json';
-import { SCIPER_ADMIN, SCIPER_OTHER_ADMIN, mockPersonalInfo } from './mocks/api';
+import {
+  SCIPER_ADMIN,
+  SCIPER_OPERATOR,
+  SCIPER_OTHER_ADMIN,
+  SCIPER_OTHER_OPERATOR,
+  mockPersonalInfo,
+} from './mocks/api';
 
 initI18n();
 
@@ -12,6 +18,7 @@ test.beforeEach(async ({ page }) => {
   // TODO integrate localisation
   i18n.changeLanguage('en'); // force 'en' for these tests
   await mockAdminList(page, [SCIPER_ADMIN, SCIPER_OTHER_ADMIN]);
+  await mockOperatorList(page, [SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR]);
   await mockPersonalInfo(page);
   await mockFormsFormID(page, 5); // mock clear election result per default
   await setUp(page, `/forms/${FORMID}/result`);

--- a/web/frontend/tests/shared.ts
+++ b/web/frontend/tests/shared.ts
@@ -5,12 +5,14 @@ import fr from './../src/language/fr.json';
 import de from './../src/language/de.json';
 import {
   SCIPER_ADMIN,
+  SCIPER_OPERATOR,
   SCIPER_OTHER_ADMIN,
+  SCIPER_OTHER_OPERATOR,
   SCIPER_USER,
   mockGetDevLogin,
   mockLogout,
   mockPersonalInfo,
-  mockProxy, SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR,
+  mockProxy,
 } from './mocks/api';
 import { mockAdminList, mockOperatorList } from './mocks/evoting';
 

--- a/web/frontend/tests/shared.ts
+++ b/web/frontend/tests/shared.ts
@@ -10,9 +10,9 @@ import {
   mockGetDevLogin,
   mockLogout,
   mockPersonalInfo,
-  mockProxy,
+  mockProxy, SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR,
 } from './mocks/api';
-import { mockAdminList } from './mocks/evoting';
+import { mockAdminList, mockOperatorList } from './mocks/evoting';
 
 export const FORMID = 'b63bcb854121051f2d8cff04bf0ac9b524b534b704509a16a423448bde3321b4';
 
@@ -34,6 +34,7 @@ export async function setUp(page: Page, url: string) {
 
 export async function logIn(page: Page, sciper: string) {
   await mockAdminList(page, [SCIPER_ADMIN, SCIPER_OTHER_ADMIN]);
+  await mockOperatorList(page, [SCIPER_OPERATOR, SCIPER_OTHER_OPERATOR]);
   await mockPersonalInfo(page, sciper);
   await page.reload({ waitUntil: 'networkidle' });
 }


### PR DESCRIPTION
The goal of this PR is to implement and adapt the management and authorization checks of the operators on the frontend. This links the role to the list on the blockchain… 

This also adds some tests and fixes the ones that were broken by the new added code.

Note that this PR will also fix an undisclosed bug, where some empty forms were listed in the form list on the frontend.

This PR would solve the 3 last points of this issue: https://github.com/c4dt/d-voting/issues/199

In addition, this PR is also based on the changes waiting to be merged in #9. The first commit specific to this branch is 53c528e1.